### PR TITLE
feat(RecentlyListenedGrid): added placeholder images and grid format

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,11 @@ done with spotify api and react
 - [x] set up linter
 - [ ] featured artists
   - [x] carousel set up
+  - [ ] body/grid set up
+  - [ ] image text set up
 - [ ] set up for backend for API calls
-- [ ] body
-- [ ] footer
-
+  - [ ] carousel loads with correct data
+  - [ ] grid loads with correct data
 
 ## Available Scripts
 

--- a/src/SpotFavs.jsx
+++ b/src/SpotFavs.jsx
@@ -1,16 +1,13 @@
 import React from 'react';
 import './SpotFavs.css';
 import FeaturedArtists from './components/FeaturedArtists';
+import RecentlyListenedGrid from './components/RecentlyListenedGrid';
 
-function SpotFavs() {
+export default function SpotFavs() {
   return (
     <>
       <FeaturedArtists />
-      <div className="work">
-        can i get a poggers in the chat
-      </div>
+      <RecentlyListenedGrid />
     </>
   );
 }
-
-export default SpotFavs;

--- a/src/components/FeaturedArtists.css
+++ b/src/components/FeaturedArtists.css
@@ -8,10 +8,11 @@ header{
 
 .carousel{
   background-color: #F8A528;
-  padding: 5em 0 7em 0;
+  padding-top: 5em ;
+  padding-bottom: 1em;
 }
 
-img{         
+.carousel img{         
   width: 30vw;
   height: 30vw;
   margin: 1em 1em;
@@ -42,7 +43,7 @@ img{
 
 .flickity-enabled.is-draggable {
   -webkit-tap-highlight-color: transparent;
-  tap-highlight-color: transparent;
+  -tap-highlight-color: transparent;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -102,7 +103,7 @@ img{
   height: 44px;
   border-radius: 50%;
   /* vertically center */
-  transform: translateY(-50%);
+  /* transform: translateY(-50%); */
 }
 
 .flickity-prev-next-button.previous {

--- a/src/components/RecentlyListenedGrid.css
+++ b/src/components/RecentlyListenedGrid.css
@@ -1,0 +1,12 @@
+
+.container{
+  background-color: #F8A528;
+  padding: 5em 0 2.5em 0;
+  display: flex;
+  flex-wrap: wrap;
+  margin: 0 auto;
+}
+
+.container img{      
+  max-width: 25%;   
+}

--- a/src/components/RecentlyListenedGrid.jsx
+++ b/src/components/RecentlyListenedGrid.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import './RecentlyListenedGrid.css';
+
+export default function RecentlyListenedGrid() {
+  return (
+
+    <div className="container">
+      <img src="https://i.scdn.co/image/ab6761610000e5eb8da3e6e26f2cd05958f17a65" alt="placeholder" />
+      <img src="https://i.scdn.co/image/ab6761610000e5eb8da3e6e26f2cd05958f17a65" alt="placeholder" />
+      <img src="https://i.scdn.co/image/ab6761610000e5eb8da3e6e26f2cd05958f17a65" alt="placeholder" />
+      <img src="https://i.scdn.co/image/ab6761610000e5eb8da3e6e26f2cd05958f17a65" alt="placeholder" />
+      <img src="https://i.scdn.co/image/ab6761610000e5eb8da3e6e26f2cd05958f17a65" alt="placeholder" />
+      <img src="https://i.scdn.co/image/ab6761610000e5eb8da3e6e26f2cd05958f17a65" alt="placeholder" />
+      <img src="https://i.scdn.co/image/ab6761610000e5eb8da3e6e26f2cd05958f17a65" alt="placeholder" />
+      <img src="https://i.scdn.co/image/ab6761610000e5eb8da3e6e26f2cd05958f17a65" alt="placeholder" />
+      <img src="https://i.scdn.co/image/ab6761610000e5eb8da3e6e26f2cd05958f17a65" alt="placeholder" />
+      <img src="https://i.scdn.co/image/ab6761610000e5eb8da3e6e26f2cd05958f17a65" alt="placeholder" />
+      <img src="https://i.scdn.co/image/ab6761610000e5eb8da3e6e26f2cd05958f17a65" alt="placeholder" />
+      <img src="https://i.scdn.co/image/ab6761610000e5eb8da3e6e26f2cd05958f17a65" alt="placeholder" />
+
+    </div>
+  );
+}


### PR DESCRIPTION
Created placeholder images for grid section below carousel
Need to adjust responsiveness for images based on browser dimensions

(ignore the dijon sorry)
![image](https://user-images.githubusercontent.com/75353560/187007302-72fd2e86-c373-4583-97fe-5e189085a8c0.png)
